### PR TITLE
Tests refactoring

### DIFF
--- a/backend/src/mock/repositories/credentials.go
+++ b/backend/src/mock/repositories/credentials.go
@@ -5,10 +5,6 @@ import (
 )
 
 var (
-  Users = []models.UserCredentials{
-    { Email: "mail@ya.ru", Password: "3dac4de4c9d5af7382da4c63f5555f2b" },
-    { Email: "me@gmail.com", Password: "0c120226ef10689396a6eabbf733e54b" },
-  }
   NotExistsUser = models.UserCredentials{
     Email: "no-way@ya.ru",
     Password: "",
@@ -18,3 +14,14 @@ var (
     Password: "some_pass",
   }
 )
+
+func GetFirstUser() models.UserCredentials {
+  return models.UserCredentials{
+    Email: UsersCredentials[0]["email"].(string),
+    Password: UsersCredentials[0]["password"].(string),
+  }
+}
+
+func GetNextUserId() uint {
+  return uint(len(UsersCredentials) + 1)
+}

--- a/backend/src/mock/repositories/meetings.go
+++ b/backend/src/mock/repositories/meetings.go
@@ -6,27 +6,6 @@ import (
 )
 
 var (
-  FirstLabeledPlace = models.LabeledPlace{
-    Label: "221b baker street",
-    PublicPlace: models.PublicPlace{
-      Latitude: 51.5207,
-      Longitude: -0.1550,
-    },
-  }
-  PublicPlaces = []models.PublicPlace{
-    {
-      Latitude: 51.5207,
-      Longitude: -0.155,
-    },
-    {
-      Latitude: 0,
-      Longitude: 0,
-    },
-    {
-      Latitude: 51.5207,
-      Longitude: -0.155,
-    },
-  }
   FirstUserStatuses = []string{
     "invited", "not-invited", "not-invited",
   }
@@ -36,3 +15,25 @@ var (
   }
   ExpectedDate = time.Date(2020, 3, 2, 20, 0, 0, 0, time.UTC)
 )
+
+func GetFirstLabeledPlace() models.LabeledPlace {
+  return models.LabeledPlace{
+    Label: MeetingsPlaces[0]["label"].(string),
+    PublicPlace: models.PublicPlace{
+      Latitude: models.Latitude(MeetingsPlaces[0]["latitude"].(float64)),
+      Longitude: models.Longitude(MeetingsPlaces[0]["longitude"].(float64)),
+    },
+  }
+}
+
+func GetNotExistsMeetingId() uint {
+  return uint(len(Meetings) + 1)
+}
+
+func GetPlaceLongitudeById(idx int) models.Longitude {
+  return models.Longitude(MeetingsPlaces[idx]["longitude"].(float64))
+}
+
+func GetPlaceLatitudeById(idx int) models.Latitude {
+  return models.Latitude(MeetingsPlaces[idx]["latitude"].(float64))
+}

--- a/backend/src/mock/repositories/user_settings.go
+++ b/backend/src/mock/repositories/user_settings.go
@@ -5,16 +5,6 @@ import (
 )
 
 var (
-  FirstUserSettings = models.FullUserInfo{
-    UserSettings: models.UserSettings{
-      Name: "J. Smith", Nickname: "mather_fucker", Gender: "male", Age: 12,
-    },
-    Rating: []models.Rating{
-      {Tag: "tag1", Value: 65},
-      {Tag: "tag2", Value: 55},
-      {Tag: "tag3", Value: 43},
-    },
-  }
   TestInfo = models.UserSettings{
     Nickname: "some_nickname",
     Gender: "male",
@@ -37,4 +27,24 @@ func SettingsEqual(s1, s2 models.FullUserInfo) bool {
   }
 
   return true
+}
+
+func GetFirstUserSettings() models.FullUserInfo {
+  return models.FullUserInfo{
+    UserSettings: models.UserSettings{
+      Name: UsersInfo[0]["name"].(string),
+      Nickname: UsersInfo[0]["nickname"].(string),
+      Gender: UsersInfo[0]["gender"].(string),
+      Age: uint(UsersInfo[0]["age"].(int)),
+    },
+    Rating: []models.Rating{
+      {Tag: UsersRating[0]["tag"].(string), Value: float64(UsersRating[0]["value"].(int))},
+      {Tag: UsersRating[1]["tag"].(string), Value: float64(UsersRating[1]["value"].(int))},
+      {Tag: UsersRating[2]["tag"].(string), Value: float64(UsersRating[2]["value"].(int))},
+    },
+  }
+}
+
+func GetNotExistsUserId() uint {
+  return uint(len(UsersCredentials) + 1)
 }

--- a/backend/src/mock/repositories/utils.go
+++ b/backend/src/mock/repositories/utils.go
@@ -1,6 +1,9 @@
 package repositories
 
-import "github.com/jmoiron/sqlx"
+import (
+  "github.com/jmoiron/sqlx"
+  "github.com/lib/pq"
+)
 
 const (
   DropTablesQuery = `
@@ -104,43 +107,82 @@ const (
     text TEXT NOT NULL,
     sending_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
   );`
-  CreateDataQuery = `
-  INSERT INTO users(email, password) VALUES('mail@ya.ru', '3dac4de4c9d5af7382da4c63f5555f2b');
-  INSERT INTO users(email, password) VALUES('me@gmail.com', '0c120226ef10689396a6eabbf733e54b');
-  INSERT INTO users(email, password) VALUES('hello.world@mail.ru', '3dac4de4c9d5af7382da4c63f5555f2b');
-  INSERT INTO users(email, password) VALUES('world@hello.ru', '3dac4de4c9d5af7382da4c63f5555f2b');
-
-  INSERT INTO users_info(user_id, name, nickname, gender, age) VALUES(1, 'J. Smith', 'mather_fucker', 'male', 12);
-  INSERT INTO users_info(user_id, name, nickname, age, avatar_url) VALUES(2, 'Mr. Anderson', 'LoL228', 8, 'http://123.png');
-  INSERT INTO users_info(user_id, name, nickname, age) VALUES(3, 'Alex', 'nagibator', 21);
-
-  INSERT INTO users_rating(user_id, tag, value) VALUES(1, 'tag1', 65);
-  INSERT INTO users_rating(user_id, tag, value) VALUES(1, 'tag2', 55);
-  INSERT INTO users_rating(user_id, tag, value) VALUES(1, 'tag3', 43);
-
-  INSERT INTO users_rating(user_id, tag, value) VALUES(2, 'tag1', 40);
-  INSERT INTO users_rating(user_id, tag, value) VALUES(2, 'tag2', 90);
-  INSERT INTO users_rating(user_id, tag, value) VALUES(2, 'tag3', 55);
-
-  INSERT INTO users_rating(user_id, tag, value) VALUES(3, 'tag1', 40);
-  INSERT INTO users_rating(user_id, tag, value) VALUES(3, 'tag2', 90);
-  INSERT INTO users_rating(user_id, tag, value) VALUES(3, 'tag3', 55);
-
-  INSERT INTO meetings(admin_id, user_ids) VALUES(1, ARRAY[1]);
-  INSERT INTO meetings(admin_id, user_ids) VALUES(2, ARRAY[2, 4]);
-  INSERT INTO meetings(admin_id, user_ids) VALUES(3, ARRAY[3]);
-
+  CreateUserQuery = `INSERT INTO users(email, password) VALUES(:email, :password);`
+  CreateUserInfoQuery = `
+  INSERT INTO users_info(user_id, name, nickname, age, gender)
+  VALUES(:user_id, :name, :nickname, :age, :gender);`
+  CreateUserRatingQuery = `INSERT INTO users_rating(user_id, tag, value) VALUES(:user_id, :tag, :value);`
+  CreateMeetingQuery = `INSERT INTO meetings(admin_id, user_ids) VALUES(:admin_id, :user_ids);`
+  CreateMeetingSettingsQuery = `
   INSERT INTO meetings_settings(meeting_id, title, date_time, tags, duration)
-  VALUES(1, 'hello_world', '2020-03-02T14:00:00', ARRAY['tag1', 'tag2'], 4);
-  INSERT INTO meetings_settings(meeting_id, title, date_time, tags, duration)
-  VALUES(2, 'hello_world', '2020-03-02T16:00:00', ARRAY['tag3'], 4);
-  INSERT INTO meetings_settings(meeting_id, title, date_time, tags, duration)
-  VALUES(3, 'hello_world', '2020-03-02T20:00:00', ARRAY['tag1'], 4);
+  VALUES(:meeting_id, :title, :date_time, :tags, :duration);`
+  CreateMeetingPlaceQuery = `
+  INSERT INTO meetings_places(meeting_id, label, latitude, longitude)
+  VALUES(:meeting_id, :label, :latitude, :longitude);`
+)
 
-  INSERT INTO meetings_places(meeting_id, label, latitude, longitude) VALUES(1, '221b baker street', 51.5207, -0.1550);
-  INSERT INTO meetings_places(meeting_id, label, latitude, longitude) VALUES(2, 'hello-world', 0.0, 0.0);
-  INSERT INTO meetings_places(meeting_id, label, latitude, longitude) VALUES(3, '221b baker street', 51.5207, -0.1550);
-  `
+var (
+  UsersCredentials = []map[string]interface{}{
+    {"email": "mail@ya.ru", "password": "3dac4de4c9d5af7382da4c63f5555f2b"},
+    {"email": "me@gmail.com", "password": "0c120226ef10689396a6eabbf733e54b"},
+    {"email": "hello.world@mail.ru", "password": "3dac4de4c9d5af7382da4c63f5555f2b"},
+    {"email": "world@hello.ru", "password": "3dac4de4c9d5af7382da4c63f5555f2b"},
+  }
+  UsersInfo = []map[string]interface{}{
+    {"user_id": 1, "name": "J. Smith", "nickname": "mather_fucker", "age": 12, "gender": "male"},
+    {"user_id": 2, "name": "Mr. Anderson", "nickname": "Lol228", "age": 8, "gender": "male"},
+    {"user_id": 3, "name": "Alex", "nickname": "nagibator", "age": 21, "gender": "female"},
+  }
+  UsersRating = []map[string]interface{}{
+    {"user_id": 1, "tag": "tag1", "value": 65},
+    {"user_id": 1, "tag": "tag2", "value": 55},
+    {"user_id": 1, "tag": "tag3", "value": 43},
+    {"user_id": 2, "tag": "tag1", "value": 40},
+    {"user_id": 2, "tag": "tag2", "value": 90},
+    {"user_id": 2, "tag": "tag3", "value": 55},
+    {"user_id": 3, "tag": "tag1", "value": 40},
+    {"user_id": 3, "tag": "tag2", "value": 90},
+    {"user_id": 3, "tag": "tag3", "value": 55},
+  }
+  Meetings = []map[string]interface{}{
+    {"admin_id": 1, "user_ids": pq.Array([]uint{1})},
+    {"admin_id": 2, "user_ids": pq.Array([]uint{2, 4})},
+    {"admin_id": 3, "user_ids": pq.Array([]uint{3})},
+  }
+  MeetingsSettings = []map[string]interface{}{
+    {
+      "meeting_id": 1,
+      "title": "hello_world",
+      "date_time": "2020-03-02T14:00:00",
+      "tags": pq.Array([]string{"tag1", "tag2"}),
+      "duration": 4,
+    },
+    {
+      "meeting_id": 2,
+      "title": "hello_world",
+      "date_time": "2020-03-02T16:00:00",
+      "tags": pq.Array([]string{"tag3"}),
+      "duration": 4,
+    },
+    {
+      "meeting_id": 3,
+      "title": "hello_world",
+      "date_time": "2020-03-02T20:00:00",
+      "tags": pq.Array([]string{"tag1"}),
+      "duration": 4,
+    },
+  }
+  MeetingsPlaces = []map[string]interface{}{
+    {"meeting_id": 1, "label": "221b baker street", "latitude": 51.5207, "longitude": -0.1550},
+    {"meeting_id": 2, "label": "hello-world", "latitude": 0.0, "longitude": 0.0},
+    {"meeting_id": 3, "label": "221b baker street", "latitude": 51.5207, "longitude": -0.1550},
+  }
+  QueryToSubData = map[string][]map[string]interface{}{
+    CreateUserInfoQuery: UsersInfo,
+    CreateUserRatingQuery: UsersRating,
+    CreateMeetingSettingsQuery: MeetingsSettings,
+    CreateMeetingPlaceQuery: MeetingsPlaces,
+  }
 )
 
 func DropTables(db *sqlx.DB) {
@@ -151,13 +193,38 @@ func DropTables(db *sqlx.DB) {
 }
 
 func InitTables(db *sqlx.DB) {
+  DropTables(db)
   _, err := db.Exec(CreateTablesQuery)
   if err != nil {
     panic(err)
   }
 
-  _, err = db.Exec(CreateDataQuery)
-  if err != nil {
+  insertData(db)
+}
+
+func insertData(db *sqlx.DB) {
+  tx := db.MustBegin()
+  addDataFromSource(tx, CreateUserQuery, UsersCredentials)
+  addDataFromSource(tx, CreateMeetingQuery, Meetings)
+  if err := tx.Commit(); err != nil {
     panic(err)
+  }
+
+  tx = db.MustBegin()
+  for query, data := range QueryToSubData {
+    addDataFromSource(tx, query, data)
+  }
+  if err := tx.Commit(); err != nil {
+    panic(err)
+  }
+}
+
+func addDataFromSource(tx *sqlx.Tx, query string, src []map[string]interface{}) {
+  for _, item := range src {
+    _, err := tx.NamedExec(query, item)
+
+    if err != nil {
+      panic(err)
+    }
   }
 }

--- a/backend/src/repositories/credentials/credentials_test.go
+++ b/backend/src/repositories/credentials/credentials_test.go
@@ -46,7 +46,7 @@ func TestRepository_GetUserIdByCredentialsSuccess(t *testing.T) {
   mock.InitTables(db)
   defer mock.DropTables(db)
 
-  id, err := repository.GetUserIdByCredentials(mock.Users[0])
+  id, err := repository.GetUserIdByCredentials(mock.GetFirstUser())
 
   utils.AssertNil(err, t)
   utils.AssertEqual(1, int(id), t)
@@ -64,7 +64,7 @@ func TestRepository_GetUserIdByCredentialsErrorUserNotExists(t *testing.T) {
 func TestRepository_GetUserIdByCredentialsErrorNoTable(t *testing.T) {
   mock.DropTables(db)
 
-  _, err := repository.GetUserIdByCredentials(mock.Users[0])
+  _, err := repository.GetUserIdByCredentials(mock.GetFirstUser())
   utils.AssertNotNil(err, t)
 }
 
@@ -76,14 +76,14 @@ func TestRepository_CreateUserSuccess(t *testing.T) {
   utils.AssertNil(err, t)
 
   id, _ := repository.GetUserIdByCredentials(mock.NewUser)
-  utils.AssertEqual(5, int(id), t)
+  utils.AssertEqual(mock.GetNextUserId(), id, t)
 }
 
 func TestRepository_CreateUserEmailExistsError(t *testing.T) {
   mock.InitTables(db)
   defer mock.DropTables(db)
 
-  err := repository.CreateUser(mock.Users[0])
+  err := repository.CreateUser(mock.GetFirstUser())
   utils.AssertErrorsEqual(internal_errors.UnableToRegisterUserEmailExists, err, t)
 }
 
@@ -91,7 +91,7 @@ func TestRepository_UpdateUserPasswordSuccess(t *testing.T) {
   mock.InitTables(db)
   defer mock.DropTables(db)
 
-  user := mock.Users[0]
+  user := mock.GetFirstUser()
   user.Password = "new_pass"
   err := repository.UpdateUserPassword(user)
   utils.AssertNil(err, t)
@@ -111,7 +111,7 @@ func TestRepository_UpdateUserPasswordUserNotFoundError(t *testing.T) {
 func TestRepository_UpdateUserPasswordErrorNoTable(t *testing.T) {
   mock.DropTables(db)
 
-  err := repository.UpdateUserPassword(mock.Users[0])
+  err := repository.UpdateUserPassword(mock.GetFirstUser())
   utils.AssertNotNil(err, t)
 }
 
@@ -121,14 +121,14 @@ func TestRepository_GetUserEmailSuccess(t *testing.T) {
 
   email, err := repository.GetUserEmail(1)
   utils.AssertNil(err, t)
-  utils.AssertEqual(mock.Users[0].Email, email, t)
+  utils.AssertEqual(mock.GetFirstUser().Email, email, t)
 }
 
 func TestRepository_GetUserEmailUserNotFoundError(t *testing.T) {
   mock.InitTables(db)
   defer mock.DropTables(db)
 
-  _, err := repository.GetUserEmail(11)
+  _, err := repository.GetUserEmail(mock.GetNotExistsUserId())
   utils.AssertErrorsEqual(internal_errors.UnableToFindUserById, err, t)
 }
 

--- a/backend/src/repositories/meetings/meetings_test.go
+++ b/backend/src/repositories/meetings/meetings_test.go
@@ -51,21 +51,21 @@ func TestRepository_GetFullMeetingInfoSuccess(t *testing.T) {
 
   info, err := repository.GetFullMeetingInfo(1)
   utils.AssertNil(err, t)
-  utils.AssertEqual(mock.FirstLabeledPlace, info.LabeledPlace, t)
+  utils.AssertEqual(mock.GetFirstLabeledPlace(), info.LabeledPlace, t)
 }
 
 func TestRepository_GetFullMeetingInfoMeetingNotFoundError(t *testing.T) {
   mock.InitTables(db)
   defer mock.DropTables(db)
 
-  _, err := repository.GetFullMeetingInfo(11)
+  _, err := repository.GetFullMeetingInfo(mock.GetNotExistsMeetingId())
   utils.AssertErrorsEqual(internal_errors.UnableToFindByMeetingId, err, t)
 }
 
 func TestRepository_GetFullMeetingInfoNoTableError(t *testing.T) {
   mock.DropTables(db)
 
-  _, err := repository.GetFullMeetingInfo(11)
+  _, err := repository.GetFullMeetingInfo(mock.GetNotExistsMeetingId())
   utils.AssertNotNil(err, t)
 }
 
@@ -76,8 +76,8 @@ func TestRepository_GetPublicMeetingsSuccess(t *testing.T) {
   meetings, err := repository.GetPublicMeetings()
   utils.AssertNil(err, t)
   for idx, meeting := range meetings {
-    utils.AssertEqual(mock.PublicPlaces[idx].Longitude, meeting.PublicPlace.Longitude, t)
-    utils.AssertEqual(mock.PublicPlaces[idx].Latitude, meeting.PublicPlace.Latitude, t)
+    utils.AssertEqual(mock.GetPlaceLongitudeById(idx), meeting.PublicPlace.Longitude, t)
+    utils.AssertEqual(mock.GetPlaceLatitudeById(idx), meeting.PublicPlace.Latitude, t)
   }
 }
 
@@ -128,14 +128,14 @@ func TestRepository_CreateMeetingAdminNotFoundError(t *testing.T) {
   mock.InitTables(db)
   defer mock.DropTables(db)
 
-  err := repository.CreateMeeting(11, mock2.NewMeetingSettings)
+  err := repository.CreateMeeting(mock.GetNotExistsUserId(), mock2.NewMeetingSettings)
   utils.AssertErrorsEqual(internal_errors.UnableToFindUserById, err, t)
 }
 
 func TestRepository_CreateMeetingNoTableError(t *testing.T) {
   mock.DropTables(db)
 
-  err := repository.CreateMeeting(11, mock2.NewMeetingSettings)
+  err := repository.CreateMeeting(mock.GetNotExistsMeetingId(), mock2.NewMeetingSettings)
   utils.AssertNotNil(err, t)
 }
 
@@ -153,14 +153,14 @@ func TestRepository_DeleteMeetingMeetingNotFoundError(t *testing.T) {
   mock.InitTables(db)
   defer mock.DropTables(db)
 
-  err := repository.DeleteMeeting(11)
+  err := repository.DeleteMeeting(mock.GetNotExistsMeetingId())
   utils.AssertErrorsEqual(internal_errors.UnableToFindByMeetingId, err, t)
 }
 
 func TestRepository_DeleteMeetingNoTableError(t *testing.T) {
   mock.DropTables(db)
 
-  err := repository.DeleteMeeting(11)
+  err := repository.DeleteMeeting(mock.GetNotExistsMeetingId())
   utils.AssertNotNil(err, t)
 }
 
@@ -178,13 +178,13 @@ func TestRepository_UpdatedSettingsMeetingNotFoundError(t *testing.T) {
   mock.InitTables(db)
   defer mock.DropTables(db)
 
-  err := repository.UpdatedSettings(11, mock2.NewMeetingSettings)
+  err := repository.UpdatedSettings(mock.GetNotExistsMeetingId(), mock2.NewMeetingSettings)
   utils.AssertErrorsEqual(internal_errors.UnableToFindByMeetingId, err, t)
 }
 
 func TestRepository_UpdatedSettingsNoTableError(t *testing.T) {
   mock.DropTables(db)
 
-  err := repository.UpdatedSettings(11, mock2.NewMeetingSettings)
+  err := repository.UpdatedSettings(mock.GetNotExistsMeetingId(), mock2.NewMeetingSettings)
   utils.AssertNotNil(err, t)
 }

--- a/backend/src/repositories/user_settings/user_settings_test.go
+++ b/backend/src/repositories/user_settings/user_settings_test.go
@@ -48,21 +48,21 @@ func TestRepository_GetUserInfoSuccess(t *testing.T) {
 
   userSettings, err := repository.GetUserSettings(1)
   utils.AssertNil(err, t)
-  utils.AssertTrue(mock.SettingsEqual(mock.FirstUserSettings, userSettings), t)
+  utils.AssertTrue(mock.SettingsEqual(mock.GetFirstUserSettings(), userSettings), t)
 }
 
 func TestRepository_GetUserInfoUserNoFoundError(t *testing.T) {
   mock.InitTables(db)
   defer mock.DropTables(db)
 
-  _, err := repository.GetUserSettings(11)
+  _, err := repository.GetUserSettings(mock.GetNotExistsUserId())
   utils.AssertErrorsEqual(internal_errors.UnableToFindUserById, err, t)
 }
 
 func TestRepository_GetUserInfoErrorNoTable(t *testing.T) {
   mock.DropTables(db)
 
-  _, err := repository.GetUserSettings(11)
+  _, err := repository.GetUserSettings(mock.GetNotExistsUserId())
   utils.AssertNotNil(err, t)
 }
 
@@ -81,7 +81,7 @@ func TestRepository_UpdateUserInfoUserNoFoundError(t *testing.T) {
   mock.InitTables(db)
   defer mock.DropTables(db)
 
-  err := repository.UpdateUserSettings(11, mock.TestInfo)
+  err := repository.UpdateUserSettings(mock.GetNotExistsUserId(), mock.TestInfo)
   utils.AssertErrorsEqual(internal_errors.UnableToFindUserById, err, t)
 }
 


### PR DESCRIPTION
1. Переписал код ```mock/repositories/utils.go``` - теперь данные заливаются не из raw-sql, а из структур, что позволило избавиться от дублирования во всем пакете ```/mock/repositories```.

2. Заменил "магические" константы вызовами функций с нормальными именами; как результат - более понятный тестовый код