### PR TITLE
Services refactoring

### DIFF
--- a/backend/src/interfaces/errors.go
+++ b/backend/src/interfaces/errors.go
@@ -1,0 +1,8 @@
+package interfaces
+
+type (
+  ErrorWrapper interface {
+    OriginalError() error
+    ExternalError() error
+  }
+)

--- a/backend/src/models/errors.go
+++ b/backend/src/models/errors.go
@@ -1,0 +1,22 @@
+package models
+
+type (
+  ErrorWrapper struct {
+    originalError, externalError error
+  }
+)
+
+func NewErrorWrapper(originalError, externalError error) ErrorWrapper {
+  return ErrorWrapper{
+    originalError: originalError,
+    externalError: externalError,
+  }
+}
+
+func (e ErrorWrapper) OriginalError() error {
+  return e.originalError
+}
+
+func (e ErrorWrapper) ExternalError() error {
+  return e.externalError
+}

--- a/backend/src/services/authentication/auth_test.go
+++ b/backend/src/services/authentication/auth_test.go
@@ -1,21 +1,13 @@
 package authentication
 
 import (
-  "io/ioutil"
-  "log"
   mock "mock/services"
-  "os"
   "services"
   "testing"
   "utils"
 )
 
 var authService = New(&mock.CredentialsRepo)
-
-func TestMain(m *testing.M) {
-  log.SetOutput(ioutil.Discard)
-  os.Exit(m.Run())
-}
 
 func TestAuthService_RegisterUserSuccess(t *testing.T) {
   defer mock.CredentialsRepo.ResetState()
@@ -32,14 +24,14 @@ func TestAuthService_RegisterUserEmailExistsError(t *testing.T) {
   defer mock.CredentialsRepo.ResetState()
 
   err := authService.RegisterUser(mock.ExistingUserEmail)
-  utils.AssertErrorsEqual(EmailExists, err, t)
+  utils.AssertErrorsEqual(EmailExists, err.ExternalError(), t)
 }
 
 func TestAuthService_RegisterUserInternalError(t *testing.T) {
   defer mock.CredentialsRepo.ResetState()
 
   err := authService.RegisterUser(mock.BadUser)
-  utils.AssertErrorsEqual(services.InternalError, err, t)
+  utils.AssertErrorsEqual(services.InternalError, err.ExternalError(), t)
 }
 
 func TestAuthService_LoginSuccess(t *testing.T) {
@@ -52,13 +44,13 @@ func TestAuthService_LoginSuccess(t *testing.T) {
 func TestAuthService_LoginCredentialsNotFoundError(t *testing.T) {
   _, err := authService.Login(mock.NewUser)
 
-  utils.AssertErrorsEqual(CredentialsNotFound, err, t)
+  utils.AssertErrorsEqual(CredentialsNotFound, err.ExternalError(), t)
 }
 
 func TestAuthService_LoginInternalError(t *testing.T) {
   _, err := authService.Login(mock.BadUser)
 
-  utils.AssertErrorsEqual(services.InternalError, err, t)
+  utils.AssertErrorsEqual(services.InternalError, err.ExternalError(), t)
 }
 
 func TestAuthService_ChangePasswordSuccess(t *testing.T) {
@@ -75,17 +67,17 @@ func TestAuthService_ChangePasswordSuccess(t *testing.T) {
 func TestAuthService_ChangePasswordUserNotFoundError(t *testing.T) {
   err := authService.ChangePassword(11, "")
 
-  utils.AssertErrorsEqual(services.UserIdNotFound, err, t)
+  utils.AssertErrorsEqual(services.UserIdNotFound, err.ExternalError(), t)
 }
 
 func TestAuthService_ChangePasswordInternalError_1(t *testing.T) {
   err := authService.ChangePassword(1, mock.BadUser.Password)
 
-  utils.AssertErrorsEqual(services.InternalError, err, t)
+  utils.AssertErrorsEqual(services.InternalError, err.ExternalError(), t)
 }
 
 func TestAuthService_ChangePasswordInternalError_2(t *testing.T) {
   err := authService.ChangePassword(mock.BadUserId, "")
 
-  utils.AssertErrorsEqual(services.InternalError, err, t)
+  utils.AssertErrorsEqual(services.InternalError, err.ExternalError(), t)
 }

--- a/backend/src/services/meetings/meetings_test.go
+++ b/backend/src/services/meetings/meetings_test.go
@@ -1,22 +1,14 @@
 package meetings
 
 import (
-  "io/ioutil"
-  "log"
   mock "mock/services"
   "models"
-  "os"
   "services"
   "testing"
   "utils"
 )
 
 var service = New(&mock.MeetingsMockRepository)
-
-func TestMain(m *testing.M) {
-  log.SetOutput(ioutil.Discard)
-  os.Exit(m.Run())
-}
 
 func TestService_GetPublicMeetingsSuccess(t *testing.T) {
   defer mock.MeetingsMockRepository.ResetState()
@@ -33,7 +25,7 @@ func TestService_GetPublicMeetingsInternalError(t *testing.T) {
   defer mock.MeetingsMockRepository.ResetState()
 
   _, err := service.GetPublicMeetings()
-  utils.AssertErrorsEqual(services.InternalError, err, t)
+  utils.AssertErrorsEqual(services.InternalError, err.ExternalError(), t)
 }
 
 func TestService_GetExtendedMeetingsSuccess(t *testing.T) {
@@ -54,14 +46,14 @@ func TestService_GetExtendedMeetingsUserNotFoundError(t *testing.T) {
   defer mock.MeetingsMockRepository.ResetState()
 
   _, err := service.GetExtendedMeetings(mock.NotExistsUserId)
-  utils.AssertErrorsEqual(services.UserIdNotFound, err, t)
+  utils.AssertErrorsEqual(services.UserIdNotFound, err.ExternalError(), t)
 }
 
 func TestService_GetExtendedMeetingsInternalError(t *testing.T) {
   defer mock.MeetingsMockRepository.ResetState()
 
   _, err := service.GetExtendedMeetings(mock.BadUserId)
-  utils.AssertErrorsEqual(services.InternalError, err, t)
+  utils.AssertErrorsEqual(services.InternalError, err.ExternalError(), t)
 }
 
 func TestService_GetFullMeetingInfoSuccess(t *testing.T) {
@@ -77,14 +69,14 @@ func TestService_GetFullMeetingInfoMeetingNotFoundError(t *testing.T) {
   defer mock.MeetingsMockRepository.ResetState()
 
   _, err := service.GetFullMeetingInfo(mock.NotExistsMeetingId)
-  utils.AssertErrorsEqual(services.MeetingIdNotFound, err, t)
+  utils.AssertErrorsEqual(services.MeetingIdNotFound, err.ExternalError(), t)
 }
 
 func TestService_GetFullMeetingInfoInternalError(t *testing.T) {
   defer mock.MeetingsMockRepository.ResetState()
 
   _, err := service.GetFullMeetingInfo(mock.BadMeetingId)
-  utils.AssertErrorsEqual(services.InternalError, err, t)
+  utils.AssertErrorsEqual(services.InternalError, err.ExternalError(), t)
 }
 
 func TestService_DeleteMeetingSuccess(t *testing.T) {
@@ -100,14 +92,14 @@ func TestService_DeleteMeetingNotFoundError(t *testing.T) {
   defer mock.MeetingsMockRepository.ResetState()
 
   err := service.DeleteMeeting(mock.NotExistsMeetingId)
-  utils.AssertErrorsEqual(services.MeetingIdNotFound, err, t)
+  utils.AssertErrorsEqual(services.MeetingIdNotFound, err.ExternalError(), t)
 }
 
 func TestService_DeleteMeetingInternalError(t *testing.T) {
   defer mock.MeetingsMockRepository.ResetState()
 
   err := service.DeleteMeeting(mock.BadMeetingId)
-  utils.AssertErrorsEqual(services.InternalError, err, t)
+  utils.AssertErrorsEqual(services.InternalError, err.ExternalError(), t)
 }
 
 func TestService_CreateMeetingSuccess(t *testing.T) {
@@ -123,14 +115,14 @@ func TestService_CreateMeetingUserIdNotFoundError(t *testing.T) {
   defer mock.MeetingsMockRepository.ResetState()
 
   err := service.CreateMeeting(mock.NotExistsUserId, mock.NewMeetingSettings)
-  utils.AssertErrorsEqual(services.UserIdNotFound, err, t)
+  utils.AssertErrorsEqual(services.UserIdNotFound, err.ExternalError(), t)
 }
 
 func TestService_CreateMeetingInternalError(t *testing.T) {
   defer mock.MeetingsMockRepository.ResetState()
 
   err := service.CreateMeeting(mock.BadUserId, mock.NewMeetingSettings)
-  utils.AssertErrorsEqual(services.InternalError, err, t)
+  utils.AssertErrorsEqual(services.InternalError, err.ExternalError(), t)
 }
 
 func TestService_UpdatedSettingsSuccess(t *testing.T) {
@@ -146,12 +138,12 @@ func TestService_UpdatedSettingsMeetingNotFoundError(t *testing.T) {
   defer mock.MeetingsMockRepository.ResetState()
 
   err := service.UpdatedSettings(mock.NotExistsMeetingId, mock.NewMeetingSettings)
-  utils.AssertErrorsEqual(services.MeetingIdNotFound, err, t)
+  utils.AssertErrorsEqual(services.MeetingIdNotFound, err.ExternalError(), t)
 }
 
 func TestService_UpdatedSettings(t *testing.T) {
   defer mock.MeetingsMockRepository.ResetState()
 
   err := service.UpdatedSettings(mock.BadMeetingId, mock.NewMeetingSettings)
-  utils.AssertErrorsEqual(services.InternalError, err, t)
+  utils.AssertErrorsEqual(services.InternalError, err.ExternalError(), t)
 }

--- a/backend/src/services/participation/participation_test.go
+++ b/backend/src/services/participation/participation_test.go
@@ -1,11 +1,8 @@
 package participation
 
 import (
-  "io/ioutil"
-  "log"
   mock "mock/services"
   "models"
-  "os"
   "services"
   "testing"
   "utils"
@@ -15,11 +12,6 @@ var service = New(
   &mock.UsersSettingsRepository,
   &mock.MeetingsSettingsRepository,
 )
-
-func TestMain(m *testing.M) {
-  log.SetOutput(ioutil.Discard)
-  os.Exit(m.Run())
-}
 
 func TestService_HandleParticipationRequestBadRating(t *testing.T) {
   info, err := service.HandleParticipationRequest(mock.BadRatingRequest)
@@ -54,43 +46,43 @@ func TestService_HandleParticipationRequestWrongGender(t *testing.T) {
 func TestService_HandleParticipationRequestUserIdNotFound(t *testing.T) {
   _, err := service.HandleParticipationRequest(mock.NotExistsUserIdRequest)
 
-  utils.AssertErrorsEqual(services.UserIdNotFound, err, t)
+  utils.AssertErrorsEqual(services.UserIdNotFound, err.ExternalError(), t)
 }
 
 func TestService_HandleParticipationRequestMeetingIdNotFound(t *testing.T) {
   _, err := service.HandleParticipationRequest(mock.NotExistsMeetingIdRequest)
 
-  utils.AssertErrorsEqual(services.MeetingIdNotFound, err, t)
+  utils.AssertErrorsEqual(services.MeetingIdNotFound, err.ExternalError(), t)
 }
 
 func TestService_HandleParticipationRequestInternalError1(t *testing.T) {
   _, err := service.HandleParticipationRequest(mock.InternalErrorRequest1)
 
-  utils.AssertErrorsEqual(services.InternalError, err, t)
+  utils.AssertErrorsEqual(services.InternalError, err.ExternalError(), t)
 }
 
 func TestService_HandleParticipationRequestInternalError2(t *testing.T) {
   _, err := service.HandleParticipationRequest(mock.InternalErrorRequest2)
 
-  utils.AssertErrorsEqual(services.InternalError, err, t)
+  utils.AssertErrorsEqual(services.InternalError, err.ExternalError(), t)
 }
 
 func TestService_HasNearMeetingRequestInternalError3(t *testing.T) {
   _, err := service.hasNearMeeting(mock.InternalErrorRequest2, models.ParticipationMeetingSettings{})
 
-  utils.AssertErrorsEqual(services.InternalError, err, t)
+  utils.AssertErrorsEqual(services.InternalError, err.ExternalError(), t)
 }
 
 func TestService_HasNearMeetingRequestMeetingNotFound(t *testing.T) {
   _, err := service.hasNearMeeting(mock.NotExistsMeetingIdRequest, models.ParticipationMeetingSettings{})
 
-  utils.AssertErrorsEqual(services.MeetingIdNotFound, err, t)
+  utils.AssertErrorsEqual(services.MeetingIdNotFound, err.ExternalError(), t)
 }
 
 func TestService_HasNearMeetingRequestUserNotFound(t *testing.T) {
   _, err := service.hasNearMeeting(mock.NotExistsUserIdRequest, models.ParticipationMeetingSettings{})
 
-  utils.AssertErrorsEqual(services.UserIdNotFound, err, t)
+  utils.AssertErrorsEqual(services.UserIdNotFound, err.ExternalError(), t)
 }
 
 func TestService_HandleParticipationRequestHasNearMeeting(t *testing.T) {

--- a/backend/src/services/session/session_test.go
+++ b/backend/src/services/session/session_test.go
@@ -2,8 +2,6 @@ package session
 
 import (
   "fmt"
-  "io/ioutil"
-  "log"
   mock "mock/services"
   "net/http"
   "os"
@@ -11,7 +9,7 @@ import (
   "utils"
 )
 
-var sessionController Controller
+var sessionController Service
 
 func init() {
   coderKey := os.Getenv("CODER_KEY")
@@ -54,11 +52,6 @@ func getRequestWithInvalidSession() *http.Request {
   return req
 }
 
-func TestMain(m *testing.M) {
-  log.SetOutput(ioutil.Discard)
-  os.Exit(m.Run())
-}
-
 func TestController_GetSessionSuccess(t *testing.T) {
   session, err := sessionController.GetSession(getRequestWithSession())
 
@@ -69,13 +62,13 @@ func TestController_GetSessionSuccess(t *testing.T) {
 func TestController_GetSessionNoAuthCookieError(t *testing.T) {
   _, err := sessionController.GetSession(getRequestWithoutSession())
 
-  utils.AssertErrorsEqual(NoAuthCookie, err, t)
+  utils.AssertErrorsEqual(NoAuthCookie, err.ExternalError(), t)
 }
 
 func TestController_GetSessionInvalidCookieError(t *testing.T) {
   _, err := sessionController.GetSession(getRequestWithInvalidSession())
 
-  utils.AssertErrorsEqual(InvalidAuthCookie, err, t)
+  utils.AssertErrorsEqual(InvalidAuthCookie, err.ExternalError(), t)
 }
 
 func TestController_SetSessionSuccess(t *testing.T) {
@@ -85,8 +78,8 @@ func TestController_SetSessionSuccess(t *testing.T) {
 
   utils.AssertNil(err, t)
 
-  cookie, err := req.Cookie(cookieSessionKey)
-  utils.AssertNil(err, t)
+  cookie, e := req.Cookie(cookieSessionKey)
+  utils.AssertNil(e, t)
   utils.AssertEqual(mock.TestToken, cookie.Value, t)
 }
 

--- a/backend/src/services/user_settings/user_settings.go
+++ b/backend/src/services/user_settings/user_settings.go
@@ -4,66 +4,37 @@ import (
   "interfaces"
   "internal_errors"
   "models"
-  "plugins/logger"
   "services"
 )
 
-type UsersSettingsService struct {
+type Service struct {
   repository interfaces.UsersSettingsRepository
 }
 
-func New(repository interfaces.UsersSettingsRepository) UsersSettingsService {
-  return UsersSettingsService{repository: repository}
+func New(repository interfaces.UsersSettingsRepository) Service {
+  return Service{repository: repository}
 }
 
-func (u UsersSettingsService) GetUserSettings(userId uint) (models.FullUserInfo, error) {
+func (u Service) GetUserSettings(userId uint) (models.FullUserInfo, interfaces.ErrorWrapper) {
   info, err := u.repository.GetUserSettings(userId)
 
   switch err {
   case nil:
     return info, nil
   case internal_errors.UnableToFindUserById:
-    logger.WithFields(logger.Fields{
-      MessageTemplate: err.Error(),
-      Optional: map[string]interface{}{
-        "user_id": userId,
-      },
-    }, logger.Warning)
-    return models.FullUserInfo{}, services.UserIdNotFound
+    return models.FullUserInfo{}, models.NewErrorWrapper(err, services.UserIdNotFound)
   default:
-    logger.WithFields(logger.Fields{
-      MessageTemplate: "unable to get user info: %v",
-      Args: []interface{}{err},
-      Optional: map[string]interface{}{
-        "user_id": userId,
-      },
-    }, logger.Error)
-    return models.FullUserInfo{}, services.InternalError
+    return models.FullUserInfo{}, models.NewErrorWrapper(err, services.InternalError)
   }
 }
 
-func (u UsersSettingsService) UpdateUserSettings(userId uint, info models.UserSettings) error {
+func (u Service) UpdateUserSettings(userId uint, info models.UserSettings) interfaces.ErrorWrapper {
   switch err := u.repository.UpdateUserSettings(userId, info); err {
   case nil:
     return nil
   case internal_errors.UnableToFindUserById:
-    logger.WithFields(logger.Fields{
-      MessageTemplate: err.Error(),
-      Optional: map[string]interface{}{
-        "user_id": userId,
-        "info": info,
-      },
-    }, logger.Warning)
-    return services.UserIdNotFound
+    return models.NewErrorWrapper(err, services.UserIdNotFound)
   default:
-    logger.WithFields(logger.Fields{
-      MessageTemplate: "unable to update user info: %v",
-      Args: []interface{}{err},
-      Optional: map[string]interface{}{
-        "user_id": userId,
-        "info": info,
-      },
-    }, logger.Error)
-    return services.InternalError
+    return models.NewErrorWrapper(err, services.InternalError)
   }
 }

--- a/backend/src/services/user_settings/user_settings_test.go
+++ b/backend/src/services/user_settings/user_settings_test.go
@@ -1,21 +1,13 @@
 package user_settings
 
 import (
-  "io/ioutil"
-  "log"
   mock "mock/services"
-  "os"
   "services"
   "testing"
   "utils"
 )
 
 var service = New(&mock.UsersSettingsRepository)
-
-func TestMain(m *testing.M) {
-  log.SetOutput(ioutil.Discard)
-  os.Exit(m.Run())
-}
 
 func TestUsersSettingsService_GetUserInfoSuccess(t *testing.T) {
   defer mock.UsersSettingsRepository.ResetState()
@@ -28,13 +20,13 @@ func TestUsersSettingsService_GetUserInfoSuccess(t *testing.T) {
 func TestUsersSettingsService_GetUserInfoUserNotFoundError(t *testing.T) {
   _, err := service.GetUserSettings(11)
 
-  utils.AssertErrorsEqual(services.UserIdNotFound, err, t)
+  utils.AssertErrorsEqual(services.UserIdNotFound, err.ExternalError(), t)
 }
 
 func TestUsersSettingsService_GetUserInfoInternalError(t *testing.T) {
   _, err := service.GetUserSettings(mock.BadUserId)
 
-  utils.AssertErrorsEqual(services.InternalError, err, t)
+  utils.AssertErrorsEqual(services.InternalError, err.ExternalError(), t)
 }
 
 func TestUsersSettingsService_UpdateUserInfoSuccess(t *testing.T) {
@@ -48,11 +40,11 @@ func TestUsersSettingsService_UpdateUserInfoSuccess(t *testing.T) {
 func TestUsersSettingsService_UpdateUserInfoUserNotFoundError(t *testing.T) {
   err := service.UpdateUserSettings(11, mock.NewUserInfo)
 
-  utils.AssertErrorsEqual(services.UserIdNotFound, err, t)
+  utils.AssertErrorsEqual(services.UserIdNotFound, err.ExternalError(), t)
 }
 
 func TestUsersSettingsService_UpdateUserInfoInternalError(t *testing.T) {
   err := service.UpdateUserSettings(mock.BadUserId, mock.NewUserInfo)
 
-  utils.AssertErrorsEqual(services.InternalError, err, t)
+  utils.AssertErrorsEqual(services.InternalError, err.ExternalError(), t)
 }


### PR DESCRIPTION
Удалил логирование в сервисах, заменив его пробрасыванием обеих ошибок (ошибка, которую вернул репозиторий или плагин, и ошибка, которую нужно отдать на фронт) наружу
Почему раньше логировали там:
1. Есть инфа о входных параметрах, пришедших в http-запросе
2. Есть инфа об ошибке из репозитория или плагина

Теперь будем логировать в контроллере (т.е. в обработчике http-запросов), т.к. там будет вообще вся инфа из запроса + сервисы теперь возвращают оригинальную ошибку 

Почему я решил убрать логирование из сервисов:
1. Занимает слишком много места 
2. Ввиду пункта 1 мешает понять логику, реализуемую сервисом