### PR TITLE
Mock cleanup

### DIFF
--- a/backend/src/mock/repositories/meetings.go
+++ b/backend/src/mock/repositories/meetings.go
@@ -16,8 +16,8 @@ var (
   ExpectedDate = time.Date(2020, 3, 2, 20, 0, 0, 0, time.UTC)
 )
 
-func GetFirstLabeledPlace() models.LabeledPlace {
-  return models.LabeledPlace{
+func GetFirstLabeledPlace() *models.LabeledPlace {
+  return &models.LabeledPlace{
     Label: MeetingsPlaces[0]["label"].(string),
     PublicPlace: models.PublicPlace{
       Latitude: models.Latitude(MeetingsPlaces[0]["latitude"].(float64)),

--- a/backend/src/mock/repositories/utils.go
+++ b/backend/src/mock/repositories/utils.go
@@ -3,6 +3,7 @@ package repositories
 import (
   "github.com/jmoiron/sqlx"
   "github.com/lib/pq"
+  "utils"
 )
 
 const (
@@ -114,20 +115,18 @@ const (
   CreateUserRatingQuery = `INSERT INTO users_rating(user_id, tag, value) VALUES(:user_id, :tag, :value);`
   CreateMeetingQuery = `INSERT INTO meetings(admin_id, user_ids) VALUES(:admin_id, :user_ids);`
   CreateMeetingSettingsQuery = `
-  INSERT INTO meetings_settings(meeting_id, title, date_time, tags, duration)
-  VALUES(:meeting_id, :title, :date_time, :tags, :duration);`
+  INSERT INTO meetings_settings(meeting_id, title, date_time, tags, duration, max_users, min_age, gender)
+  VALUES(:meeting_id, :title, :date_time, :tags, :duration, :max_users, :min_age, :gender);`
   CreateMeetingPlaceQuery = `
   INSERT INTO meetings_places(meeting_id, label, latitude, longitude)
   VALUES(:meeting_id, :label, :latitude, :longitude);`
 )
 
 var (
-  // all passwords are 'mYStRoNg*PwD12'
+  TestingPassword = "mYStRoNg*PwD12"
   UsersCredentials = []map[string]interface{}{
-    {"email": "mail@ya.ru", "password": "4409ae9505d657bfeb51a875059e8d1c"},
-    {"email": "me@gmail.com", "password": "b868a6c97c67fc75b35af0e482b02143"},
-    {"email": "hello.world@mail.ru", "password": "c9d669040d46452e93435db552aa782f"},
-    {"email": "world@hello.ru", "password": "b0fd7f596010a80a30845a9b0111ede0"},
+    {"email": "mail@ya.ru"}, {"email": "me@gmail.com"},
+    {"email": "hello.world@mail.ru"}, {"email": "world@hello.ru"},
   }
   UsersInfo = []map[string]interface{}{
     {"user_id": 1, "name": "J. Smith", "nickname": "mather_fucker", "age": 12, "gender": "male"},
@@ -157,6 +156,9 @@ var (
       "date_time": "2020-03-02T14:00:00",
       "tags": pq.Array([]string{"tag1", "tag2"}),
       "duration": 4,
+      "max_users": 10,
+      "min_age": 16,
+      "gender": "male",
     },
     {
       "meeting_id": 2,
@@ -164,6 +166,9 @@ var (
       "date_time": "2020-03-02T16:00:00",
       "tags": pq.Array([]string{"tag3"}),
       "duration": 4,
+      "max_users": 5,
+      "min_age": 18,
+      "gender": "female",
     },
     {
       "meeting_id": 3,
@@ -171,6 +176,9 @@ var (
       "date_time": "2020-03-02T20:00:00",
       "tags": pq.Array([]string{"tag1"}),
       "duration": 4,
+      "max_users": 6,
+      "min_age": 12,
+      "gender": "male",
     },
   }
   MeetingsPlaces = []map[string]interface{}{
@@ -185,6 +193,12 @@ var (
     CreateMeetingPlaceQuery: MeetingsPlaces,
   }
 )
+
+func init() {
+  for idx, c := range UsersCredentials {
+    UsersCredentials[idx]["password"] = utils.GetHash(c["email"].(string) + TestingPassword)
+  }
+}
 
 func DropTables(db *sqlx.DB) {
   _, err := db.Exec(DropTablesQuery)

--- a/backend/src/mock/services/authentication.go
+++ b/backend/src/mock/services/authentication.go
@@ -3,6 +3,7 @@ package services
 import (
   "errors"
   "internal_errors"
+  "mock/repositories"
   "models"
   "utils"
 )
@@ -12,25 +13,12 @@ type CredentialsMock struct {
 }
 
 var (
-  Users = []models.UserCredentials{
-    {Email: "mail@ya.ru", Password: "hello_world"},
-    {Email: "mail@gmail.com", Password: "hi_there"},
-  }
-  usersWithHashedPassword = []models.UserCredentials{
-    {Email: "mail@ya.ru", Password: "99cef3d35538f52fca31516cea7a5ee4"},
-    {Email: "mail@gmail.com", Password: "93a23777000f3507a34969f2e7a38a7c"},
-  }
   CredentialsRepo = CredentialsMock{
-    Users: usersWithHashedPassword,
+    Users: allUsersCredentials(),
   }
-
   NewUser = models.UserCredentials{
     Email: "test@test.ru",
     Password: "pass",
-  }
-  ExistingUserEmail = models.UserCredentials{
-    Email: "mail@ya.ru",
-    Password: "3dac4de4c9d5af7382da4c63f5555f2b",
   }
   BadUser = models.UserCredentials{
     Email: "bad-email@ya.ru",
@@ -42,7 +30,7 @@ var (
 )
 
 func (c *CredentialsMock) ResetState() {
-  c.Users = usersWithHashedPassword
+  c.Users = allUsersCredentials()
 }
 
 func (c *CredentialsMock) CreateUser(user models.UserCredentials) error {
@@ -109,4 +97,23 @@ func (c *CredentialsMock) GetUserEmail(userId uint) (string, error) {
   }
 
   return "", internal_errors.UnableToFindUserById
+}
+
+func FirstUserCredentials() models.UserCredentials {
+  return models.UserCredentials{
+    Email: repositories.UsersCredentials[0]["email"].(string),
+    Password: repositories.TestingPassword,
+  }
+}
+
+func allUsersCredentials() []models.UserCredentials {
+  var credentials []models.UserCredentials
+  for _, c := range repositories.UsersCredentials {
+    credentials = append(credentials, models.UserCredentials{
+      Email: c["email"].(string),
+      Password: c["password"].(string),
+    })
+  }
+
+  return credentials
 }

--- a/backend/src/models/meeting.go
+++ b/backend/src/models/meeting.go
@@ -78,7 +78,7 @@ type (
   // for invited users
   PrivateMeeting struct {
     DefaultMeeting
-    LabeledPlace
+    *LabeledPlace
     AllSettings
   }
 )

--- a/backend/src/repositories/meetings/meetings.go
+++ b/backend/src/repositories/meetings/meetings.go
@@ -64,7 +64,9 @@ func New(db *sqlx.DB) Repository {
 }
 
 func (r Repository) GetFullMeetingInfo(meetingId uint) (models.PrivateMeeting, error) {
-  var info models.PrivateMeeting
+  var info = models.PrivateMeeting{
+    LabeledPlace: &models.LabeledPlace{},
+  }
   rows, err := r.db.Query(FullMeetingInfoQuery, meetingId)
   if err != nil {
     return info, err

--- a/backend/src/repositories/meetings/meetings_test.go
+++ b/backend/src/repositories/meetings/meetings_test.go
@@ -51,7 +51,9 @@ func TestRepository_GetFullMeetingInfoSuccess(t *testing.T) {
 
   info, err := repository.GetFullMeetingInfo(1)
   utils.AssertNil(err, t)
-  utils.AssertEqual(mock.GetFirstLabeledPlace(), info.LabeledPlace, t)
+  utils.AssertEqual(mock.GetFirstLabeledPlace().Label, info.LabeledPlace.Label, t)
+  utils.AssertEqual(mock.GetFirstLabeledPlace().GetLatitude(), info.LabeledPlace.GetLatitude(), t)
+  utils.AssertEqual(mock.GetFirstLabeledPlace().GetLongitude(), info.LabeledPlace.GetLongitude(), t)
 }
 
 func TestRepository_GetFullMeetingInfoMeetingNotFoundError(t *testing.T) {
@@ -121,7 +123,9 @@ func TestRepository_CreateMeetingSuccess(t *testing.T) {
   err := repository.CreateMeeting(1, mock2.NewMeetingSettings)
   utils.AssertNil(err, t)
   meeting, _ := repository.GetFullMeetingInfo(4)
-  utils.AssertEqual(mock2.NewMeetingSettings.LabeledPlace, meeting.LabeledPlace, t)
+  utils.AssertEqual(mock2.NewMeetingSettings.Label, meeting.LabeledPlace.Label, t)
+  utils.AssertEqual((&mock2.NewMeetingSettings).GetLatitude(), meeting.LabeledPlace.GetLatitude(), t)
+  utils.AssertEqual((&mock2.NewMeetingSettings).GetLongitude(), meeting.LabeledPlace.GetLongitude(), t)
 }
 
 func TestRepository_CreateMeetingAdminNotFoundError(t *testing.T) {

--- a/backend/src/services/authentication/auth_test.go
+++ b/backend/src/services/authentication/auth_test.go
@@ -23,7 +23,7 @@ func TestAuthService_RegisterUserSuccess(t *testing.T) {
 func TestAuthService_RegisterUserEmailExistsError(t *testing.T) {
   defer mock.CredentialsRepo.ResetState()
 
-  err := authService.RegisterUser(mock.ExistingUserEmail)
+  err := authService.RegisterUser(mock.FirstUserCredentials())
   utils.AssertErrorsEqual(errors.EmailExists, err, t)
 }
 
@@ -35,7 +35,7 @@ func TestAuthService_RegisterUserInternalError(t *testing.T) {
 }
 
 func TestAuthService_LoginSuccess(t *testing.T) {
-  userSession, err := authService.Login(mock.Users[0])
+  userSession, err := authService.Login(mock.FirstUserCredentials())
 
   utils.AssertNil(err, t)
   utils.AssertEqual(1, int(userSession.ID), t)

--- a/backend/src/services/participation/participation_test.go
+++ b/backend/src/services/participation/participation_test.go
@@ -1,11 +1,11 @@
 package participation
 
 import (
-	mock "mock/services"
-	"models"
-	"services/errors"
-	"testing"
-	"utils"
+  mock "mock/services"
+  "models"
+  "services/errors"
+  "testing"
+  "utils"
 )
 
 var service = New(
@@ -13,89 +13,83 @@ var service = New(
   &mock.MeetingsSettingsRepository,
 )
 
-func TestService_HandleParticipationRequestBadRating(t *testing.T) {
-  info, err := service.HandleParticipationRequest(mock.BadRatingRequest)
+func TestService_HandleParticipationRequestTooLowRatingTags(t *testing.T) {
+  request, tags := mock.TooLowRatingTagsRequest()
+  info, err := service.HandleParticipationRequest(request)
 
   utils.AssertNil(err, t)
-  utils.AssertTrue(info.HasNearMeeting, t)
-  utils.AssertTrue(mock.TagsEqual(mock.TagsWithBadRating, info.TooLowRatingTags), t)
-  utils.AssertEqual(0, len(info.InappropriateInfoFields), t)
-}
-
-func TestService_HandleParticipationRequestMeetingFull(t *testing.T) {
-  info, err := service.HandleParticipationRequest(mock.MeetingFullRequest)
-
-  utils.AssertNil(err, t)
-  utils.AssertEqual(mock.MaxUsersCountReached, info.InappropriateInfoFields[0], t)
-}
-
-func TestService_HandleParticipationRequestInappropriateAge(t *testing.T) {
-  info, err := service.HandleParticipationRequest(mock.InappropriateAgeRequest)
-
-  utils.AssertNil(err, t)
-  utils.AssertEqual(mock.InappropriateAge, info.InappropriateInfoFields[0], t)
-}
-
-func TestService_HandleParticipationRequestWrongGender(t *testing.T) {
-  info, err := service.HandleParticipationRequest(mock.WrongGenderRequest)
-
-  utils.AssertNil(err, t)
-  utils.AssertEqual(mock.WrongGender, info.InappropriateInfoFields[0], t)
-}
-
-func TestService_HandleParticipationRequestFewInappropriateInfoFields(t *testing.T) {
-  info, err := service.HandleParticipationRequest(mock.FewInappropriateInfoFields)
-
-  utils.AssertNil(err, t)
-  utils.AssertEqual(mock.MaxUsersCountReached, info.InappropriateInfoFields[0], t)
-  utils.AssertEqual(mock.InappropriateAge, info.InappropriateInfoFields[1], t)
-}
-
-func TestService_HandleParticipationRequestUserIdNotFound(t *testing.T) {
-  _, err := service.HandleParticipationRequest(mock.NotExistsUserIdRequest)
-
-  utils.AssertErrorsEqual(errors.UserIdNotFound, err, t)
-}
-
-func TestService_HandleParticipationRequestMeetingIdNotFound(t *testing.T) {
-  _, err := service.HandleParticipationRequest(mock.NotExistsMeetingIdRequest)
-
-  utils.AssertErrorsEqual(errors.MeetingIdNotFound, err, t)
-}
-
-func TestService_HandleParticipationRequestInternalError1(t *testing.T) {
-  _, err := service.HandleParticipationRequest(mock.InternalErrorRequest1)
-
-  utils.AssertErrorsEqual(errors.InternalError, err, t)
-}
-
-func TestService_HandleParticipationRequestInternalError2(t *testing.T) {
-  _, err := service.HandleParticipationRequest(mock.InternalErrorRequest2)
-
-  utils.AssertErrorsEqual(errors.InternalError, err, t)
-}
-
-func TestService_HasNearMeetingRequestInternalError3(t *testing.T) {
-  _, err := service.hasNearMeeting(mock.InternalErrorRequest2, models.ParticipationMeetingSettings{})
-
-  utils.AssertErrorsEqual(errors.InternalError, err, t)
-}
-
-func TestService_HasNearMeetingRequestMeetingNotFound(t *testing.T) {
-  _, err := service.hasNearMeeting(mock.NotExistsMeetingIdRequest, models.ParticipationMeetingSettings{})
-
-  utils.AssertErrorsEqual(errors.MeetingIdNotFound, err, t)
-}
-
-func TestService_HasNearMeetingRequestUserNotFound(t *testing.T) {
-  _, err := service.hasNearMeeting(mock.NotExistsUserIdRequest, models.ParticipationMeetingSettings{})
-
-  utils.AssertErrorsEqual(errors.UserIdNotFound, err, t)
+  utils.AssertTrue(mock.TagsEqual(tags, info.TooLowRatingTags), t)
 }
 
 func TestService_HandleParticipationRequestHasNearMeeting(t *testing.T) {
-  info, err := service.HandleParticipationRequest(mock.HasNearMeetingRequest)
+  info, err := service.HandleParticipationRequest(mock.HasNearMeetingRequest())
 
   utils.AssertNil(err, t)
   utils.AssertTrue(info.HasNearMeeting, t)
+}
+
+func TestService_HandleParticipationRequestInappropriateAge(t *testing.T) {
+  request, inappropriateAgeField := mock.InappropriateAgeRequest()
+  info, err := service.HandleParticipationRequest(request)
+
+  utils.AssertNil(err, t)
+  utils.AssertTrue(mock.HasField(info.InappropriateInfoFields, inappropriateAgeField), t)
+}
+
+func TestService_HandleParticipationRequestWrongGender(t *testing.T) {
+  request, inappropriateGenderField := mock.WrongGenderRequest()
+  info, err := service.HandleParticipationRequest(request)
+
+  utils.AssertNil(err, t)
+  utils.AssertTrue(mock.HasField(info.InappropriateInfoFields, inappropriateGenderField), t)
+}
+
+func TestService_HandleParticipationRequestMaxUsersCountReached(t *testing.T) {
+  request, maxUsersCountReachedField := mock.MaxUsersCountReachedRequest()
+  info, err := service.HandleParticipationRequest(request)
+
+  utils.AssertNil(err, t)
+  utils.AssertTrue(mock.HasField(info.InappropriateInfoFields, maxUsersCountReachedField), t)
+}
+
+func TestService_HandleParticipationRequestNotExistsMeeting(t *testing.T) {
+  _, err := service.HandleParticipationRequest(mock.NotExistsMeetingRequest())
+
+  utils.AssertErrorsEqual(errors.MeetingIdNotFound, err, t)
+}
+
+func TestService_HandleParticipationRequestNotExistsUser(t *testing.T) {
+  _, err := service.HandleParticipationRequest(mock.NotExistsUserRequest())
+
+  utils.AssertErrorsEqual(errors.UserIdNotFound, err, t)
+}
+
+func TestService_HandleParticipationRequestInternalErrorBadMeetingId(t *testing.T) {
+  _, err := service.HandleParticipationRequest(mock.InternalErrorBadMeetingIdRequest())
+
+  utils.AssertErrorsEqual(errors.InternalError, err, t)
+}
+
+func TestService_HasNearMeetingNotExistsMeeting(t *testing.T) {
+  _, err := service.hasNearMeeting(mock.NotExistsMeetingRequest(), models.ParticipationMeetingSettings{})
+
+  utils.AssertErrorsEqual(errors.MeetingIdNotFound, err, t)
+}
+
+func TestService_HasNearMeetingNotExistsUser(t *testing.T) {
+  _, err := service.hasNearMeeting(mock.NotExistsUserRequest(), models.ParticipationMeetingSettings{})
+
+  utils.AssertErrorsEqual(errors.UserIdNotFound, err, t)
+}
+
+func TestService_HandleParticipationRequestInternalErrorBadUserId(t *testing.T) {
+  _, err := service.HandleParticipationRequest(mock.InternalErrorUserIdRequest())
+
+  utils.AssertErrorsEqual(errors.InternalError, err, t)
+}
+
+func TestService_HasNearMeetingInternalError(t *testing.T) {
+  _, err := service.hasNearMeeting(mock.InternalErrorBadMeetingIdRequest(), models.ParticipationMeetingSettings{})
+
+  utils.AssertErrorsEqual(errors.InternalError, err, t)
 }

--- a/prepare_workspace.sh
+++ b/prepare_workspace.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function prepareFolders() {
-  mkdir $1/backend/test_report
+  mkdir $1/backend/test_report 2>/dev/null
 }
 
 function prepareFiles() {

--- a/scripts/go_tests.sh
+++ b/scripts/go_tests.sh
@@ -14,8 +14,10 @@ rm -rf ${REPORT_FOLDER}/*
 for dir in "${folders[@]}"
 do
   reportFileName=$(echo -n ${dir} | md5sum | awk '{print $1}')
-  cd ${GOPATH}/src/${dir} && go test -coverprofile=${REPORT_FOLDER}/${reportFileName}.out
+  reportFilePath=${REPORT_FOLDER}/${reportFileName}
+  cd ${GOPATH}/src/${dir} && go test -coverprofile=${reportFilePath}.out
   if [[ $1 = html ]]; then # open reports in browser
-    go tool cover -html=${REPORT_FOLDER}/${reportFileName}.out
+    go tool cover -html=${reportFilePath}.out -o ${reportFilePath}.html
+    chromium ${reportFilePath}.html >/dev/null 2>&1 &
   fi
 done


### PR DESCRIPTION
Главное - переписал моки на использование структур данных, которые мы заливаем в БД для тестов. Убрал "магические" константы и переменные - теперь используем функции по большей части

Переписал тесты для participation сервиса, т.к. моки для них были очень грязные (ну а тесты их использовали)